### PR TITLE
Use of index.js file to export folder modules

### DIFF
--- a/server/daos/index.js
+++ b/server/daos/index.js
@@ -1,0 +1,2 @@
+const renamer = (module_name) => module_name.replace(/_dao/,'');
+module.exports = require('require-directory')(module, {rename: renamer});

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,0 +1,1 @@
+module.exports = require('require-directory')(module);

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
     "morgan": "^1.10.0",
     "node-cron": "^2.0.3",
     "nodemailer": "^6.4.15",
+    "require-directory": "^2.1.1",
     "sqlite3": "^5.0.0",
     "swagger-jsdoc": "^5.0.1",
     "swagger-ui-express": "^4.1.4"

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -1,0 +1,2 @@
+const renamer = (module_name) => module_name.replace(/Route/,'');
+module.exports = require('require-directory')(module, {rename: renamer});

--- a/server/services/courseStudentService.js
+++ b/server/services/courseStudentService.js
@@ -1,4 +1,4 @@
-const courseStudentDao = require('../daos/course_student');
+const courseStudentDao = require('../daos/course_student_dao');
 const errHandler = require('./errorHandler');
 
 exports.createCourseStudentTable = async function() {    

--- a/server/services/index.js
+++ b/server/services/index.js
@@ -1,0 +1,2 @@
+const renamer = (module_name) => module_name.replace(/Service/,'');
+module.exports = require('require-directory')(module, {rename: renamer});


### PR DESCRIPTION
Use it like this
```
const services = require('../services');
...
await services.booking.assertBooking(student_id,lecture_id); 
```
The required object contains the directory files as keys, each one has the exported functions. I've tried to keep the key names equal to what the file represents, i.e. `services/coursesService.js` become `services.courses`. Console.log the imported object for confirmation.

PS: if you just want to import a single file keep doing as the past sprint

PPS: I'm sorry to tag all of you but I think this is something worth knowing before it gets lost in between `master` commits 🤐